### PR TITLE
Implement multi-threaded read and writes

### DIFF
--- a/src/server/execute.rs
+++ b/src/server/execute.rs
@@ -1,16 +1,49 @@
-use crate::server::operators::Op;
+use crate::server::operators::{Op, Select};
 use crate::{error::Error, server::record::Record};
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::{channel, Receiver, Sender};
 
-pub fn execute(operation: Op, tx: &Sender<Record>) -> Result<Option<Vec<Record>>, Error> {
-    match operation {
-        Op::Write(record) => execute_write(record, tx),
-        Op::Select(_) => {
-            println!("SELECT!");
-            Ok(None)
-        },
-        _ => Ok(None),
+pub struct SelectRequest {
+    pub statement: Select,
+    result_tx: Sender<Vec<Record>>,
+}
+
+impl SelectRequest {
+    fn new(s: Select) -> (Self, Receiver<Vec<Record>>) {
+        let (tx, rx): (Sender<Vec<Record>>, Receiver<Vec<Record>>) = channel();
+        (
+            SelectRequest {
+                statement: s,
+                result_tx: tx,
+            },
+            rx,
+        )
     }
+
+    pub fn reply(&self, r: Vec<Record>) {
+        self.result_tx.send(r).unwrap();
+    }
+}
+
+pub fn execute(
+    operation: Op,
+    read_tx: &Sender<SelectRequest>,
+    write_tx: &Sender<Record>,
+) -> Result<Option<Vec<Record>>, Error> {
+    match operation {
+        Op::Write(record) => execute_write(record, write_tx),
+        Op::Select(statement) => execute_select(statement, read_tx),
+    }
+}
+
+fn execute_select(
+    statement: Select,
+    tx: &Sender<SelectRequest>,
+) -> Result<Option<Vec<Record>>, Error> {
+    let (request, rx) = SelectRequest::new(statement);
+    tx.send(request).unwrap();
+    let result = rx.recv().unwrap();
+    println!("Received result: {:?}", result);
+    Ok(Some(result))
 }
 
 fn execute_write(record: Record, tx: &Sender<Record>) -> Result<Option<Vec<Record>>, Error> {

--- a/src/server/operators/mod.rs
+++ b/src/server/operators/mod.rs
@@ -10,6 +10,8 @@ pub enum Op {
     Write(Record),
 }
 
+pub use select::Select;
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/server/operators/select.rs
+++ b/src/server/operators/select.rs
@@ -1,32 +1,32 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Select {
     name: String,
     predicate: Predicate,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Predicate {
     name: String,
     condition: Conditions,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub enum Conditions {
     Leaf(Condition),
     And(Box<Conditions>, Box<Conditions>),
     Or(Box<Conditions>, Box<Conditions>),
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Condition {
     lhs: Type,
     rhs: Type,
     op: Op,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub enum Type {
     LabelKey(String),
     LabelValue(String),
@@ -34,7 +34,7 @@ pub enum Type {
     Metric(f64),
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub enum Op {
     Eq,
     NEq,

--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    sync::{mpsc::Receiver, Arc, Mutex},
+    sync::{mpsc::Receiver, Arc, Mutex, RwLock},
     thread,
 };
 
@@ -23,7 +23,7 @@ impl Series {
     }
 }
 
-fn db_read(read_rx: Receiver<SelectRequest>, index: Arc<Mutex<HashMap<String, Series>>>) {
+fn db_read(read_rx: Receiver<SelectRequest>, index: Arc<RwLock<HashMap<String, Series>>>) {
     // Receive read operations from the server
     for request in read_rx {
         let statement = request.statement.clone();
@@ -32,27 +32,30 @@ fn db_read(read_rx: Receiver<SelectRequest>, index: Arc<Mutex<HashMap<String, Se
     }
 }
 
-fn db_write(write_rx: Receiver<Record>, index: Arc<Mutex<HashMap<String, Series>>>) {
+fn db_write(write_rx: Receiver<Record>, storage: Arc<RwLock<HashMap<String, Series>>>) {
     // Receive write operations from the server
     for received in write_rx {
         let key: String = received.get_key();
-        let mut db = index.lock().unwrap();
-        match db.get_mut(&key) {
-            Some(v) => {
-                println!("Received a familiar key!");
-                v.insert(received);
-            }
-            None => {
-                println!("First time seeing this key.");
-                db.insert(key, Series::new(received));
-            }
+        // Obtain a read lock on storage
+        let map = storage.read().expect("RwLock poisoned");
+        //
+        if let Some(series) = map.get(&key) {
+            println!("Received a familiar key!");
+            series.insert(received);
+            continue;
         }
+        // Key does not exist in map
+        println!("First time seeing this key.");
+        // Replace read lock with a write lock
+        drop(map);
+        let mut map = storage.write().expect("RwLock poisoned");
+        map.insert(key, Series::new(received));
     }
 }
 
 pub fn db_open(read_rx: Receiver<SelectRequest>, write_rx: Receiver<Record>) {
     // Create an in-memory storage structure
-    let index = Arc::new(Mutex::new(HashMap::new()));
+    let index = Arc::new(RwLock::new(HashMap::new()));
 
     // Set up separate r/w threads so that read operations don't block writes
     let read_index = Arc::clone(&index);

--- a/src/server/store.rs
+++ b/src/server/store.rs
@@ -1,24 +1,64 @@
-use std::collections::HashMap;
-use std::sync::mpsc::Receiver;
+use std::{
+    collections::HashMap,
+    sync::{mpsc::Receiver, Arc, Mutex},
+    thread,
+};
 
-use crate::server::record::Record;
+use crate::server::{execute::SelectRequest, operators::Select, record::Record};
 
-pub fn db_open(write_rx: Receiver<Record>) {
-    // Create an in-memory storage structure
-    let mut index: HashMap<String, Vec<Record>> = HashMap::new();
+struct Series {
+    records: Mutex<Vec<Record>>,
+}
 
+impl Series {
+    fn new(record: Record) -> Self {
+        Series {
+            records: Mutex::new(vec![record]),
+        }
+    }
+
+    fn insert(&self, record: Record) {
+        let mut v = self.records.lock().unwrap();
+        v.push(record);
+    }
+}
+
+fn db_read(read_rx: Receiver<SelectRequest>, index: Arc<Mutex<HashMap<String, Series>>>) {
+    // Receive read operations from the server
+    for request in read_rx {
+        let statement = request.statement.clone();
+        println!("Received statement: {:?}", statement);
+        request.reply(Vec::new());
+    }
+}
+
+fn db_write(write_rx: Receiver<Record>, index: Arc<Mutex<HashMap<String, Series>>>) {
     // Receive write operations from the server
     for received in write_rx {
         let key: String = received.get_key();
-        match index.get_mut(&key) {
+        let mut db = index.lock().unwrap();
+        match db.get_mut(&key) {
             Some(v) => {
                 println!("Received a familiar key!");
-                v.push(received);
+                v.insert(received);
             }
             None => {
                 println!("First time seeing this key.");
-                index.insert(key, vec![received]);
+                db.insert(key, Series::new(received));
             }
         }
     }
+}
+
+pub fn db_open(read_rx: Receiver<SelectRequest>, write_rx: Receiver<Record>) {
+    // Create an in-memory storage structure
+    let index = Arc::new(Mutex::new(HashMap::new()));
+
+    // Set up separate r/w threads so that read operations don't block writes
+    let read_index = Arc::clone(&index);
+    let read_thr = thread::spawn(move || db_read(read_rx, read_index));
+    let write_index = Arc::clone(&index);
+    let write_thr = thread::spawn(move || db_write(write_rx, write_index));
+    read_thr.join().unwrap();
+    write_thr.join().unwrap();
 }


### PR DESCRIPTION
These changes allow reads and writes to be handled in separate threads, with shared access to a hashmap of time series. The shared hashmap is protected by a reader-writer lock that enables multiple threads to read from the hashmap at the same time, and locks the hashmap only when inserting a reference to an unfamiliar time series.